### PR TITLE
Fix broken links

### DIFF
--- a/src/main/twirl/gitbucket/gist/list.scala.html
+++ b/src/main/twirl/gitbucket/gist/list.scala.html
@@ -27,8 +27,8 @@
       <div>
         <div>
           @avatar(gist.userName, 20)
-          <a class="strong" href="/gist/@gist.userName">@gist.userName</a> /
-          <a class="strong" href="/gist/@gist.userName/@gist.repositoryName">@gist.title</a>
+          <a class="strong" href="@path/gist/@gist.userName">@gist.userName</a> /
+          <a class="strong" href="@path/gist/@gist.userName/@gist.repositoryName">@gist.title</a>
           @if(gist.isPrivate){
             <span class="label label-warning">Secret</span>
           }


### PR DESCRIPTION
一部リンクからGitBucket本体のコンテキストパスが抜けていたので修正しました。
ヘッダー部に追加されるリンクも同様にコンテキストパスが抜けているのを発見しましたが、
こちらについては修正できていません。
(コンテキストパスを引っ張ってくる方法が見つけられませんでした)

[当該行(a href="/gist" の部分)](https://github.com/takezoe/gitbucket-gist-plugin/blob/master/src/main/scala/Plugin.scala#L17)

中途半端な修正で申し訳ありませんが、ご参考になれば幸いです。