### PR TITLE
Update to GitBucket3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is an example of GitBucket plug-in. This plug-in provides code snippet repo
 ## Instllation
 
 1. Hit `./sbt.sh package` in the root directory of this repository.
-2. Copy `target/scala-2.11/gitbucket-gist-plugin_2.11-1.1.jar` into `GITBUCKET_HOME/plugins`.
+2. Copy `target/scala-2.11/gitbucket-gist-plugin_2.11-1.2.jar` into `GITBUCKET_HOME/plugins`.
 3. Restart GitBucket.

--- a/project/build.scala
+++ b/project/build.scala
@@ -7,8 +7,8 @@ object MyBuild extends Build {
 
   val Organization = "jp.sf.amateras"
   val Name = "gitbucket-gist-plugin"
-  val Version = "1.1"
-  val ScalaVersion = "2.11.2"
+  val Version = "1.2"
+  val ScalaVersion = "2.11.6"
 
   lazy val project = Project (
     "gitbucket-gist-plugin",
@@ -25,8 +25,8 @@ object MyBuild extends Build {
       "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
     ),
     libraryDependencies ++= Seq(
-      "gitbucket"          % "gitbucket-assembly" % "3.1.1" % "provided",
-      "com.typesafe.play" %% "twirl-compiler"     % "1.0.2" % "provided",
+      "gitbucket"          % "gitbucket-assembly" % "3.2.0" % "provided",
+      "com.typesafe.play" %% "twirl-compiler"     % "1.0.4" % "provided",
       "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided"
     ),
     javacOptions in compile ++= Seq("-target", "7", "-source", "7")

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -1,4 +1,4 @@
-import gitbucket.core.service.SystemSettingsService
+import gitbucket.core.service.SystemSettingsService.SystemSettings
 import gitbucket.gist.controller.GistController
 import gitbucket.core.plugin.PluginRegistry
 import gitbucket.core.util.Version
@@ -6,15 +6,14 @@ import java.io.File
 import javax.servlet.ServletContext
 import gitbucket.gist.util.Configurations._
 
-class Plugin extends gitbucket.core.plugin.Plugin with SystemSettingsService {
+class Plugin extends gitbucket.core.plugin.Plugin {
   override val pluginId: String = "gist"
   override val pluginName: String = "Gist Plugin"
   override val description: String = "Provides Gist feature on GitBucket."
-  override val versions: List[Version] = List(Version(1, 0))
+  override val versions: List[Version] = List(Version(1, 2))
 
-  override def initialize(registry: PluginRegistry, context: ServletContext): Unit = {
+  override def initialize(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Unit = {
     // Add Snippet link to the header
-    val settings = loadSystemSettings()
     val path = settings.baseUrl.getOrElse(context.getContextPath)
     registry.addJavaScript(".*",
       s"""
@@ -43,6 +42,6 @@ class Plugin extends gitbucket.core.plugin.Plugin with SystemSettingsService {
     println("-- Gist plug-in initialized --")
   }
 
-  override def shutdown(registry: PluginRegistry, context: ServletContext): Unit = {
+  override def shutdown(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Unit = {
   }
 }


### PR DESCRIPTION
## Changed
GitBucket3.2にあわせ、下記を修正しています。
- Product version to 1.2
- Scala version to 2.11.6
- depend on GitBucket version to 3.2.0
- depend on twirl version to 1.0.4
- gitbucket.core.plugin.Plugin.scala のインタフェースにあわせ、Plugin.scala を修正 

ローカルのGitBucketでですが動作することを確認しています。
