### PR TITLE
Update plugin to version 1.3 for GitBucket3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is an example of GitBucket plug-in. This plug-in provides code snippet repo
 ## Instllation
 
 1. Hit `./sbt.sh package` in the root directory of this repository.
-2. Copy `target/scala-2.11/gitbucket-gist-plugin_2.11-1.2.jar` into `GITBUCKET_HOME/plugins`.
+2. Copy `target/scala-2.11/gitbucket-gist-plugin_2.11-1.3.jar` into `GITBUCKET_HOME/plugins`.
 3. Restart GitBucket.

--- a/project/build.scala
+++ b/project/build.scala
@@ -7,7 +7,7 @@ object MyBuild extends Build {
 
   val Organization = "jp.sf.amateras"
   val Name = "gitbucket-gist-plugin"
-  val Version = "1.2"
+  val Version = "1.3"
   val ScalaVersion = "2.11.6"
 
   lazy val project = Project (
@@ -25,7 +25,7 @@ object MyBuild extends Build {
       "amateras-repo" at "http://amateras.sourceforge.jp/mvn/"
     ),
     libraryDependencies ++= Seq(
-      "gitbucket"          % "gitbucket-assembly" % "3.2.0" % "provided",
+      "gitbucket"          % "gitbucket-assembly" % "3.3.0" % "provided",
       "com.typesafe.play" %% "twirl-compiler"     % "1.0.4" % "provided",
       "javax.servlet"      % "javax.servlet-api"  % "3.1.0" % "provided"
     ),


### PR DESCRIPTION
Copy-and-paste from similar change by @hayasshi. Works for me but possible I missed something.

Using plugin version 1.2 with GitBucket 3.3 triggers stack trace upon submit of new gist.